### PR TITLE
アイコン画像アップロードの機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,8 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
+gem 'mini_magick'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
@@ -61,6 +62,6 @@ gem 'net-pop'
 gem 'net-smtp'
 
 gem 'carrierwave'
-gem 'kaminari'
 gem 'devise'
 gem 'devise-i18n'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,10 +315,12 @@ DEPENDENCIES
   devise-i18n
   faker
   i18n_generators
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web
   listen (~> 3.3)
+  mini_magick
   net-imap
   net-pop
   net-smtp

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction]
+    keys = %i[name postal_code address self_introduction avatar]
     devise_parameter_sanitizer.permit(:sign_up, keys: keys)
     devise_parameter_sanitizer.permit(:account_update, keys: keys)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 
 class UsersController < ApplicationController
   def index
-    @users = User.order(:id).page(params[:page])
+    @users = User.with_attached_avatar.order(:id).page(params[:page])
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_one_attached :avatar
 end

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -17,3 +17,8 @@
   <%= f.label :self_introduction %>
   <%= f.text_area :self_introduction %>
 </div>
+
+<div class="field">
+  <%= f.label :avatar %>
+  <%= f.file_field :avatar %>
+</div>

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -20,5 +20,5 @@
 
 <div class="field">
   <%= f.label :avatar %>
-  <%= f.file_field :avatar %>
+  <%= f.file_field :avatar, accept: '.jpg, .png, .gif' %>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -14,6 +14,10 @@
 
   <%= render 'devise/registrations/profile_fields', f: f %>
 
+  <% if @user.avatar.attached? %>
+    <div><%= image_tag @user.avatar.variant( resize_to_limit: [40, 40] ) %></div>
+  <% end %>
+
   <div class="field">
     <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %></i>)<br />
     <%= f.password_field :password, autocomplete: "new-password" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,6 +3,7 @@
 <table>
   <thead>
     <tr>
+      <th><%= User.human_attribute_name(:avatar) %></th>
       <th><%= User.human_attribute_name(:email) %></th>
       <th><%= User.human_attribute_name(:name) %></th>
       <th><%= User.human_attribute_name(:postal_code) %></th>
@@ -14,6 +15,11 @@
   <tbody>
     <% @users.each do |user| %>
       <tr>
+        <td>
+          <% if user.avatar.attached? %>
+            <%= image_tag user.avatar %>
+          <% end %>
+        </td>
         <td><%= user.email %></td>
         <td><%= user.name %></td>
         <td><%= user.postal_code %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,7 +17,7 @@
       <tr>
         <td>
           <% if user.avatar.attached? %>
-            <%= image_tag user.avatar %>
+            <%= image_tag user.avatar.variant( resize_to_limit: [40, 40] ) %>
           <% end %>
         </td>
         <td><%= user.email %></td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@
 <p>
   <strong><%= User.human_attribute_name(:avatar) %>:</strong>
   <% if @user.avatar.attached? %>
-    <%= image_tag @user.avatar %>
+    <%= image_tag @user.avatar.variant( resize_to_limit: [40, 40] ) %>
   <% end %>
 </p>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,13 @@
 <h1><%= t('views.common.title_show', name: User.model_name.human) %></h1>
 
 <p>
+  <strong><%= User.human_attribute_name(:avatar) %>:</strong>
+  <% if @user.avatar.attached? %>
+    <%= image_tag @user.avatar %>
+  <% end %>
+</p>
+
+<p>
   <strong><%= User.human_attribute_name(:email) %>:</strong>
   <%= @user.email %>
 </p>

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -15,3 +15,4 @@ ja:
         postal_code: 郵便番号
         address: 住所
         self_introduction: 自己紹介文
+        avatar: アイコン画像

--- a/db/migrate/20220801075751_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220801075751_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_31_231050) do
+ActiveRecord::Schema.define(version: 2022_08_01_075751) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -37,4 +65,6 @@ ActiveRecord::Schema.define(version: 2021_05_31_231050) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
### やったこと
- [x] ユーザーが自分のアイコン画像をアップロードできる
- [x] ユーザー一覧画面にアイコンを表示する（未アップロードなら何も表示しない)
- [x] ユーザー詳細画面にアイコンを表示する（未アップロードなら何も表示しない）
- [x] 画像を表示する際、大きすぎる画像は適切なサイズにリサイズする（ファイルの容量を小さくしてネットワークの負荷を減らす）
- [x] 画像アップロード用に追加した項目はi18nのYAMLファイルを編集して項目名を表示させる（英語化は考慮不要）
- [x] ユーザー一覧画面とユーザー詳細画面のスクリーンショットを載せる
- [x] rubocopをパスさせ、スクリーンショットを載せる
- [x] プロフィール編集画面にも現在設定されているアイコンを表示する
- [x] アップロード可能なファイルはjpg, png, gifの3種類だけに限定する

### 課題
Activestorageのことを調べると、N+1問題というものがよく出てきました。
Userコントローラーで関係ありそうな感じがしていますが、今回の実装では必要なのか、そうでないのか判断できなかったため導入していません。

レビューよろしくお願い致します！🙏